### PR TITLE
[api test] expose Lock as Redlock.Lock

### DIFF
--- a/redlock.js
+++ b/redlock.js
@@ -62,6 +62,9 @@ Lock.prototype.extend = function extend(ttl, callback) {
 	return this.redlock.extend(this, ttl, callback);
 };
 
+// Attach a reference to Lock, which allows the application to use instanceof
+// to ensure type.
+Redlock.Lock = Lock;
 
 
 

--- a/test.js
+++ b/test.js
@@ -65,6 +65,7 @@ function test(name, clients){
 				redlock.lock(resource, 200, function(err, lock){
 					if(err) throw err;
 					assert.isObject(lock);
+					assert.instanceOf(lock, Redlock.Lock);
 					assert.isAbove(lock.expiration, Date.now()-1);
 					one = lock;
 					done();


### PR DESCRIPTION
Hello,

I'm looking at using node-redlock in [Optimalbits/bull](https://github.com/OptimalBits/bull), and it would help us to expose the Lock constructor for type assertions.

Thanks for your work!