### PR TITLE
Support executing multiple commands atomically along with redlock

### DIFF
--- a/redlock.js
+++ b/redlock.js
@@ -11,6 +11,7 @@ if(typeof EventEmitter.EventEmitter === 'function')
 
 
 // constants
+var lockScript = 'return redis.call("set", KEYS[1], ARGV[1], "NX", "PX", ARGV[2])';
 var unlockScript = 'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
 var extendScript = 'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("pexpire", KEYS[1], ARGV[2]) else return 0 end';
 
@@ -261,7 +262,7 @@ Redlock.prototype._lock = function _lock(resource, value, ttl, callback) {
 		if(value === null) {
 			value = self._random();
 			request = function(server, loop){
-				return server.set(resource, value, 'NX', 'PX', ttl, loop);
+				return server.eval(lockScript, 1, resource, value, ttl, loop);
 			};
 		}
 

--- a/test.js
+++ b/test.js
@@ -51,6 +51,19 @@ function test(name, clients){
 			});
 		});
 
+		it('supports custom script functions in options', function(){
+			var opts = {
+				lockScript: function(lockScript) { return lockScript + "and 1"},
+				unlockScript: function(unlockScript) { return unlockScript + "and 2"},
+				extendScript: function(extendScript) { return extendScript + "and 3"}
+			}
+			var customRedlock = new Redlock(clients, opts);
+			var i = 1;
+			assert.equal(customRedlock.lockScript, redlock.lockScript + "and " + i++);
+			assert.equal(customRedlock.unlockScript, redlock.unlockScript + "and " + i++);
+			assert.equal(customRedlock.extendScript, redlock.extendScript + "and " + i);
+		});
+
 		describe('callbacks', function(){
 			before(function(done) {
 				var err;


### PR DESCRIPTION
Hello,

Our use case with Optimalbits/bull is to atomically lock a resource only if other conditions are met.  This PR allows modifying the lock/unlock/extend scripts to extend the atomic functionality with pre- or post-conditions, without sacrificing or re-implementing the atomic redlock logic.

The modification only happens once on instance creation, so I think the performance hit is negligible.  I do not attempt to guarantee the correctness of a modified script, this advanced option is at the risk of the user.