### PR TITLE
Allow unlimited retries to aquire the lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Redlock cannot tell you *with certainty* if a resource is currently locked. For 
 
 That said, for many tasks it's sufficient to attempt a lock with `retryCount=0`, and treat a failure as the resource being "locked" or (more correctly) "unavailable",
 
+With `retryCount=-1` there will be unlimited retries until the lock is aquired.
+
 
 Installation
 ------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redlock",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A node.js redlock implementation for distributed redis locks",
   "main": "redlock.js",
   "scripts": {

--- a/redlock.js
+++ b/redlock.js
@@ -335,7 +335,7 @@ Redlock.prototype._lock = function _lock(resource, value, ttl, callback) {
 				return lock.unlock(function(){
 
 					// RETRY
-					if(attempts <= self.retryCount)
+					if(self.retryCount === -1 || attempts <= self.retryCount)
 						return setTimeout(attempt, Math.max(0, self.retryDelay + Math.floor((Math.random() * 2 - 1) * self.retryJitter)));
 
 					// FAILED


### PR DESCRIPTION
Useful for functions in a cluster which only should run once at a time.

Also bump to 3.1.2.