### PR TITLE
Feature/28/multi resource lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ var redlock = new Redlock(
 		// the max time in ms randomly added to retries
 		// to improve performance under high contention
 		// see https://www.awsarchitectureblog.com/2015/03/backoff.html
-        retryJitter:  200 // time in ms
+		retryJitter:  200 // time in ms
 	}
 );
 ```

--- a/redlock.js
+++ b/redlock.js
@@ -190,57 +190,57 @@ Redlock.prototype.disposer = function disposer(resource, ttl, errorHandler) {
 // attempt to restore the lock on nodes that failed to release. It is safe to re-attempt an
 // unlock or to ignore the error, as the lock will automatically expire after its timeout.
 Redlock.prototype.release =
-	Redlock.prototype.unlock = function unlock(lock, callback) {
-		var self = this;
+Redlock.prototype.unlock = function unlock(lock, callback) {
+	var self = this;
 
-		// immediately invalidate the lock
-		lock.expiration = 0;
+	// immediately invalidate the lock
+	lock.expiration = 0;
 
-		return new Promise(function(resolve, reject) {
+	return new Promise(function(resolve, reject) {
 
-			// the number of servers which have agreed to release this lock
-			var votes = 0;
+		// the number of servers which have agreed to release this lock
+		var votes = 0;
 
-			// the number of votes needed for consensus
-			var quorum = Math.floor(self.servers.length / 2) + 1;
+		// the number of votes needed for consensus
+		var quorum = Math.floor(self.servers.length / 2) + 1;
 
-			// the number of async redis calls still waiting to finish
-			var waiting = self.servers.length;
+		// the number of async redis calls still waiting to finish
+		var waiting = self.servers.length;
 
-			// release the lock on each server
-			self.servers.forEach(function(server){
-				return self.isMultiResource(lock.resource) ? server.eval([multiValueUnlockScript, lock.resource.length].concat(lock.resource).concat([lock.value]), loop) : server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
-			});
+		// release the lock on each server
+		self.servers.forEach(function(server){
+			return self.isMultiResource(lock.resource) ? server.eval([multiValueUnlockScript, lock.resource.length].concat(lock.resource).concat([lock.value]), loop) : server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
+		});
 
-			function loop(err, response) {
-				if(err) self.emit('clientError', err);
+		function loop(err, response) {
+			if(err) self.emit('clientError', err);
 
-				// - if the lock was released by this call, it will return 1
-				// - if the lock has already been released, it will return 0
-				//    - it may have been re-acquired by another process
-				//    - it may hava already been manually released
-				//    - it may have expired
+			// - if the lock was released by this call, it will return 1
+			// - if the lock has already been released, it will return 0
+			//    - it may have been re-acquired by another process
+			//    - it may hava already been manually released
+			//    - it may have expired
 
-				if(typeof response === 'string')
-					response = parseInt(response);
+			if(typeof response === 'string')
+				response = parseInt(response);
 
-				if(response === 0 || response === 1)
-					votes++;
+			if(response === 0 || response === 1)
+				votes++;
 
-				if(waiting-- > 1) return;
+			if(waiting-- > 1) return;
 
-				// SUCCESS: there is concensus and the lock is released
-				if(votes >= quorum)
-					return resolve();
+			// SUCCESS: there is concensus and the lock is released
+			if(votes >= quorum)
+				return resolve();
 
-				// FAILURE: the lock could not be released
-				return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
-			}
-		})
+			// FAILURE: the lock could not be released
+			return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
+		}
+	})
 
-			// optionally run callback
-			.nodeify(callback);
-	};
+		// optionally run callback
+		.nodeify(callback);
+};
 
 
 // extend
@@ -256,15 +256,15 @@ Redlock.prototype.extend = function extend(lock, ttl, callback) {
 	// extend the lock
 	return self._lock(lock.resource, lock.value, ttl)
 
-		// modify and return the original lock object
-		.then(function(extension){
-			lock.value      = extension.value;
-			lock.expiration = extension.expiration;
-			return lock;
-		})
+	// modify and return the original lock object
+	.then(function(extension){
+		lock.value      = extension.value;
+		lock.expiration = extension.expiration;
+		return lock;
+	})
 
-		// optionally run callback
-		.nodeify(callback);
+	// optionally run callback
+	.nodeify(callback);
 };
 
 
@@ -372,8 +372,8 @@ Redlock.prototype._lock = function _lock(resource, value, ttl, callback) {
 		return attempt();
 	})
 
-		// optionally run callback
-		.nodeify(callback);
+	// optionally run callback
+	.nodeify(callback);
 };
 
 

--- a/redlock.js
+++ b/redlock.js
@@ -15,6 +15,24 @@ var lockScript = 'return redis.call("set", KEYS[1], ARGV[1], "NX", "PX", ARGV[2]
 var unlockScript = 'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
 var extendScript = 'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("pexpire", KEYS[1], ARGV[2]) else return 0 end';
 
+// simplified algorithm:
+// - check does any key already exists - if it does return error(0)
+// - set all keys
+// - if any key set fails delete keys which were set successfully and return error(0)
+// - if everything goes well return ok(1)
+var multiValueLockScript = 'local keyExists = 0; for i, key in ipairs(KEYS) do if redis.pcall("EXISTS", key) == 1 then keyExists=1 break end end if keyExists == 1 then return 0 end; local addedKeys={}; local addFailed=0; for i, key in ipairs(KEYS) do if not redis.pcall("SET", key, ARGV[1], "NX", "PX", ARGV[2]) then addFailed=1; break end; table.insert(addedKeys, key); end if addFailed == 1 then for i, addedKey in ipairs(addedKeys) do redis.pcall("DEL", addedKey) end return 0 end return 1';
+// simplified algorithm:
+// - check do all keys exist - if any of them is missing return error(0)
+// - delete all keys
+// - return ok(1)
+var multiValueUnlockScript = 'local keyMissing = 0; for i, key in ipairs(KEYS) do if redis.pcall("EXISTS", key) == 0 then keyMissing=1 break end end if keyMissing == 1 then return 0 end; local deleteFailed=0; for i, key in ipairs(KEYS) do if not redis.pcall("DEL", key) then deleteFailed=1; end; end; if deleteFailed == 1 then return 0 end return 1';
+// simplified algorithm:
+// - check do all keys exist - if any of them is missing return error(0)
+// - extend all keys
+// - if extend fails for any key return error(0)
+// - if extend succeeds for all keys return ok(1)
+var multiValueExtendScript = 'local keyMissing = 0; for i, key in ipairs(KEYS) do if redis.pcall("EXISTS", key) == 0 then keyMissing = 1 break end end if keyMissing == 1 then return 0 end; local extendFailed = 0; for i, key in ipairs(KEYS) do if not redis.pcall("PEXPIRE", key, ARGV[2]) then extendFailed = 1; break end; end; if extendFailed == 1 then return 0 end return 1';
+
 // defaults
 var defaults = {
 	driftFactor: 0.01,
@@ -31,11 +49,11 @@ var defaults = {
 // ---------
 // This error is returned when there is an error locking a resource.
 function LockError(message, attempts) {
-	Error.call(this);
-	Error.captureStackTrace(this, LockError);
-	this.name = 'LockError';
-	this.message = message || 'Failed to lock the resource.';
-	this.attempts = attempts;
+    Error.call(this);
+    Error.captureStackTrace(this, LockError);
+    this.name = 'LockError';
+    this.message = message || 'Failed to lock the resource.';
+    this.attempts = attempts;
 }
 
 util.inherits(LockError, Error);
@@ -59,11 +77,11 @@ function Lock(redlock, resource, value, expiration, attempts) {
 }
 
 Lock.prototype.unlock = function unlock(callback) {
-	return this.redlock.unlock(this, callback);
+    return this.redlock.unlock(this, callback);
 };
 
 Lock.prototype.extend = function extend(ttl, callback) {
-	return this.redlock.extend(this, ttl, callback);
+    return this.redlock.extend(this, ttl, callback);
 };
 
 // Attach a reference to Lock, which allows the application to use instanceof
@@ -80,20 +98,22 @@ Redlock.Lock = Lock;
 // `options` object. Properties of the Redlock object should NOT be changed after it is first
 // used, as doing so could have unintended consequences for live locks.
 function Redlock(clients, options) {
-	// set default options
-	options = options || {};
-	this.driftFactor  = typeof options.driftFactor  === 'number' ? options.driftFactor : defaults.driftFactor;
+    // set default options
+    options = options || {};
+    this.driftFactor  = typeof options.driftFactor  === 'number' ? options.driftFactor : defaults.driftFactor;
 	this.retryCount   = typeof options.retryCount   === 'number' ? options.retryCount  : defaults.retryCount;
 	this.retryDelay   = typeof options.retryDelay   === 'number' ? options.retryDelay  : defaults.retryDelay;
-	this.retryJitter  = typeof options.retryJitter  === 'number' ? options.retryJitter  : defaults.retryJitter;
-	this.lockScript   = typeof options.lockScript   === 'function' ? options.lockScript(lockScript) : lockScript;
-	this.unlockScript = typeof options.unlockScript === 'function' ? options.unlockScript(unlockScript) : unlockScript;
-	this.extendScript = typeof options.extendScript === 'function' ? options.extendScript(extendScript) : extendScript;
-
-	// set the redis servers from additional arguments
-	this.servers = clients;
-	if(this.servers.length === 0)
-		throw new Error('Redlock must be instantiated with at least one redis server.');
+	this.retryJitter  = typeof options.retryJitter  === 'number' ? options.retryJitter : defaults.retryJitter;
+    this.lockScript   = typeof options.lockScript   === 'function' ? options.lockScript(lockScript) : lockScript;
+    this.unlockScript = typeof options.unlockScript === 'function' ? options.unlockScript(unlockScript) : unlockScript;
+    this.extendScript = typeof options.extendScript === 'function' ? options.extendScript(extendScript) : extendScript;
+    this.multiValueLockScript   = typeof options.multiValueLockScript   === 'function' ? options.multiValueLockScript(multiValueLockScript)     : multiValueLockScript;
+    this.multiValueUnlockScript = typeof options.multiValueUnlockScript === 'function' ? options.multiValueUnlockScript(multiValueUnlockScript) : multiValueUnlockScript;
+    this.multiValueExtendScript = typeof options.multiValueExtendScript === 'function' ? options.multiValueExtendScript(multiValueExtendScript) : multiValueExtendScript;
+    // set the redis servers from additional arguments
+    this.servers = clients;
+    if(this.servers.length === 0)
+        throw new Error('Redlock must be instantiated with at least one redis server.');
 }
 
 // Inherit all the EventEmitter methods, like `on`, and `off`
@@ -111,13 +131,13 @@ Redlock.LockError = LockError;
 
 Redlock.prototype.quit = function quit(callback) {
 
-	// quit all clients
-	return Promise.map(this.servers, function(client) {
-		return client.quit();
-	})
+    // quit all clients
+    return Promise.map(this.servers, function(client) {
+        return client.quit();
+    })
 
-	// optionally run callback
-	.nodeify(callback);
+        // optionally run callback
+        .nodeify(callback);
 };
 
 
@@ -135,9 +155,9 @@ Redlock.prototype.quit = function quit(callback) {
 // )
 // ```
 Redlock.prototype.acquire =
-Redlock.prototype.lock = function lock(resource, ttl, callback) {
-	return this._lock(resource, null, ttl, callback);
-};
+    Redlock.prototype.lock = function lock(resource, ttl, callback) {
+        return this._lock(resource, null, ttl, callback);
+    };
 
 // lock
 // ----
@@ -170,81 +190,81 @@ Redlock.prototype.disposer = function disposer(resource, ttl, errorHandler) {
 // attempt to restore the lock on nodes that failed to release. It is safe to re-attempt an
 // unlock or to ignore the error, as the lock will automatically expire after its timeout.
 Redlock.prototype.release =
-Redlock.prototype.unlock = function unlock(lock, callback) {
-	var self = this;
+    Redlock.prototype.unlock = function unlock(lock, callback) {
+        var self = this;
 
-	// immediately invalidate the lock
-	lock.expiration = 0;
+        // immediately invalidate the lock
+        lock.expiration = 0;
 
-	return new Promise(function(resolve, reject) {
+        return new Promise(function(resolve, reject) {
 
-		// the number of servers which have agreed to release this lock
-		var votes = 0;
+            // the number of servers which have agreed to release this lock
+            var votes = 0;
 
-		// the number of votes needed for consensus
-		var quorum = Math.floor(self.servers.length / 2) + 1;
+            // the number of votes needed for consensus
+            var quorum = Math.floor(self.servers.length / 2) + 1;
 
-		// the number of async redis calls still waiting to finish
-		var waiting = self.servers.length;
+            // the number of async redis calls still waiting to finish
+            var waiting = self.servers.length;
 
-		// release the lock on each server
-		self.servers.forEach(function(server){
-			server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
-		});
+            // release the lock on each server
+            self.servers.forEach(function(server){
+                return self.isMultiResource(lock.resource) ? server.eval([multiValueUnlockScript, lock.resource.length].concat(lock.resource).concat([lock.value]), loop) : server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
+            });
 
-		function loop(err, response) {
-			if(err) self.emit('clientError', err);
+            function loop(err, response) {
+                if(err) self.emit('clientError', err);
 
-			// - if the lock was released by this call, it will return 1
-			// - if the lock has already been released, it will return 0
-			//    - it may have been re-acquired by another process
-			//    - it may hava already been manually released
-			//    - it may have expired
+                // - if the lock was released by this call, it will return 1
+                // - if the lock has already been released, it will return 0
+                //    - it may have been re-acquired by another process
+                //    - it may hava already been manually released
+                //    - it may have expired
 
-			if(typeof response === 'string')
-				response = parseInt(response);
+                if(typeof response === 'string')
+                    response = parseInt(response);
 
-			if(response === 0 || response === 1)
-				votes++;
+                if(response === 0 || response === 1)
+                    votes++;
 
-			if(waiting-- > 1) return;
+                if(waiting-- > 1) return;
 
-			// SUCCESS: there is concensus and the lock is released
-			if(votes >= quorum)
-				return resolve();
+                // SUCCESS: there is concensus and the lock is released
+                if(votes >= quorum)
+                    return resolve();
 
-			// FAILURE: the lock could not be released
-			return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
-		}
-	})
+                // FAILURE: the lock could not be released
+                return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
+            }
+        })
 
-	// optionally run callback
-	.nodeify(callback);
-};
+            // optionally run callback
+            .nodeify(callback);
+    };
 
 
 // extend
 // ------
 // This method extends a valid lock by the provided `ttl`.
 Redlock.prototype.extend = function extend(lock, ttl, callback) {
-	var self = this;
+    var self = this;
 
-	// the lock has expired
-	if(lock.expiration < Date.now())
-		return Promise.reject(new LockError('Cannot extend lock on resource "' + lock.resource + '" because the lock has already expired.', 0)).nodeify(callback);
+    // the lock has expired
+    if(lock.expiration < Date.now())
+        return Promise.reject(new LockError('Cannot extend lock on resource "' + lock.resource + '" because the lock has already expired.', 0)).nodeify(callback);
 
-	// extend the lock
-	return self._lock(lock.resource, lock.value, ttl)
+    // extend the lock
+    return self._lock(lock.resource, lock.value, ttl)
 
-	// modify and return the original lock object
-	.then(function(extension){
-		lock.value      = extension.value;
-		lock.expiration = extension.expiration;
-		return lock;
-	})
+        // modify and return the original lock object
+        .then(function(extension){
+            lock.value      = extension.value;
+            lock.expiration = extension.expiration;
+            return lock;
+        })
 
-	// optionally run callback
-	.nodeify(callback);
+        // optionally run callback
+        .nodeify(callback);
 };
 
 
@@ -278,87 +298,91 @@ Redlock.prototype.extend = function extend(lock, ttl, callback) {
 // )
 // ```
 Redlock.prototype._lock = function _lock(resource, value, ttl, callback) {
-	var self = this;
-	return new Promise(function(resolve, reject) {
-		var request;
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        var request;
 
-		// the number of times we have attempted this lock
-		var attempts = 0;
-
-
-		// create a new lock
-		if(value === null) {
-			value = self._random();
-			request = function(server, loop){
-				return server.eval(self.lockScript, 1, resource, value, ttl, loop);
-			};
-		}
-
-		// extend an existing lock
-		else {
-			request = function(server, loop){
-				return server.eval(self.extendScript, 1, resource, value, ttl, loop);
-			};
-		}
-
-		function attempt(){
-			attempts++;
-
-			// the time when this attempt started
-			var start = Date.now();
-
-			// the number of servers which have agreed to this lock
-			var votes = 0;
-
-			// the number of votes needed for consensus
-			var quorum = Math.floor(self.servers.length / 2) + 1;
-
-			// the number of async redis calls still waiting to finish
-			var waiting = self.servers.length;
-
-			function loop(err, response) {
-				if(err) self.emit('clientError', err);
-				if(response) votes++;
-				if(waiting-- > 1) return;
-
-				// Add 2 milliseconds to the drift to account for Redis expires precision, which is 1 ms,
-				// plus the configured allowable drift factor
-				var drift = Math.round(self.driftFactor * ttl) + 2;
-				var lock = new Lock(self, resource, value, start + ttl - drift, attempts);
-
-				// SUCCESS: there is concensus and the lock is not expired
-				if(votes >= quorum && lock.expiration > Date.now())
-					return resolve(lock);
+        // the number of times we have attempted this lock
+        var attempts = 0;
 
 
-				// remove this lock from servers that voted for it
-				return lock.unlock(function(){
+        // create a new lock
+        if(value === null) {
+            value = self._random();
+            request = function(server, loop){
+                // alternative using spread operator [multiValueLockScript, resource.length, ...resource, value, ttl] but not supported in old js versions
+                return self.isMultiResource(resource) ? server.eval([multiValueLockScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.lockScript, 1, resource, value, ttl, loop);
+            };
+        }
 
-					// RETRY
-					if(self.retryCount === -1 || attempts <= self.retryCount)
-						return setTimeout(attempt, Math.max(0, self.retryDelay + Math.floor((Math.random() * 2 - 1) * self.retryJitter)));
+        // extend an existing lock
+        else {
+            request = function(server, loop){
+                return self.isMultiResource(resource) ? server.eval([multiValueExtendScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.extendScript, 1, resource, value, ttl, loop);
+            };
+        }
 
-					// FAILED
-					return reject(new LockError('Exceeded ' + self.retryCount + ' attempts to lock the resource "' + resource + '".', attempts));
-				});
-			}
+        function attempt(){
+            attempts++;
 
-			return self.servers.forEach(function(server){
-				return request(server, loop);
-			});
-		}
+            // the time when this attempt started
+            var start = Date.now();
 
-		return attempt();
-	})
+            // the number of servers which have agreed to this lock
+            var votes = 0;
 
-	// optionally run callback
-	.nodeify(callback);
+            // the number of votes needed for consensus
+            var quorum = Math.floor(self.servers.length / 2) + 1;
+
+            // the number of async redis calls still waiting to finish
+            var waiting = self.servers.length;
+
+            function loop(err, response) {
+                if(err) self.emit('clientError', err);
+                if(response) votes++;
+                if(waiting-- > 1) return;
+
+                // Add 2 milliseconds to the drift to account for Redis expires precision, which is 1 ms,
+                // plus the configured allowable drift factor
+                var drift = Math.round(self.driftFactor * ttl) + 2;
+                var lock = new Lock(self, resource, value, start + ttl - drift, attempts);
+
+                // SUCCESS: there is concensus and the lock is not expired
+                if(votes >= quorum && lock.expiration > Date.now())
+                    return resolve(lock);
+
+
+                // remove this lock from servers that voted for it
+                return lock.unlock(function(){
+
+                    // RETRY
+                    if(self.retryCount === -1 || attempts <= self.retryCount)
+                        return setTimeout(attempt, Math.max(0, self.retryDelay + Math.floor((Math.random() * 2 - 1) * self.retryJitter)));
+
+                    // FAILED
+                    return reject(new LockError('Exceeded ' + self.retryCount + ' attempts to lock the resource "' + resource + '".', attempts));
+                });
+            }
+
+            return self.servers.forEach(function(server){
+                return request(server, loop);
+            });
+        }
+
+        return attempt();
+    })
+
+        // optionally run callback
+        .nodeify(callback);
 };
 
 
 Redlock.prototype._random = function _random(){
-	return crypto.randomBytes(16).toString('hex');
+    return crypto.randomBytes(16).toString('hex');
 };
 
+Redlock.prototype.isMultiResource = function isMultiResource(resource) {
+    return Array.isArray(resource);
+};
 
 module.exports = Redlock;

--- a/redlock.js
+++ b/redlock.js
@@ -155,9 +155,9 @@ Redlock.prototype.quit = function quit(callback) {
 // )
 // ```
 Redlock.prototype.acquire =
-	Redlock.prototype.lock = function lock(resource, ttl, callback) {
-		return this._lock(resource, null, ttl, callback);
-	};
+Redlock.prototype.lock = function lock(resource, ttl, callback) {
+	return this._lock(resource, null, ttl, callback);
+};
 
 // lock
 // ----
@@ -238,8 +238,8 @@ Redlock.prototype.unlock = function unlock(lock, callback) {
 		}
 	})
 
-		// optionally run callback
-		.nodeify(callback);
+	// optionally run callback
+	.nodeify(callback);
 };
 
 

--- a/redlock.js
+++ b/redlock.js
@@ -49,11 +49,11 @@ var defaults = {
 // ---------
 // This error is returned when there is an error locking a resource.
 function LockError(message, attempts) {
-    Error.call(this);
-    Error.captureStackTrace(this, LockError);
-    this.name = 'LockError';
-    this.message = message || 'Failed to lock the resource.';
-    this.attempts = attempts;
+	Error.call(this);
+	Error.captureStackTrace(this, LockError);
+	this.name = 'LockError';
+	this.message = message || 'Failed to lock the resource.';
+	this.attempts = attempts;
 }
 
 util.inherits(LockError, Error);
@@ -77,11 +77,11 @@ function Lock(redlock, resource, value, expiration, attempts) {
 }
 
 Lock.prototype.unlock = function unlock(callback) {
-    return this.redlock.unlock(this, callback);
+	return this.redlock.unlock(this, callback);
 };
 
 Lock.prototype.extend = function extend(ttl, callback) {
-    return this.redlock.extend(this, ttl, callback);
+	return this.redlock.extend(this, ttl, callback);
 };
 
 // Attach a reference to Lock, which allows the application to use instanceof
@@ -98,22 +98,22 @@ Redlock.Lock = Lock;
 // `options` object. Properties of the Redlock object should NOT be changed after it is first
 // used, as doing so could have unintended consequences for live locks.
 function Redlock(clients, options) {
-    // set default options
-    options = options || {};
-    this.driftFactor  = typeof options.driftFactor  === 'number' ? options.driftFactor : defaults.driftFactor;
+	// set default options
+	options = options || {};
+	this.driftFactor  = typeof options.driftFactor  === 'number' ? options.driftFactor : defaults.driftFactor;
 	this.retryCount   = typeof options.retryCount   === 'number' ? options.retryCount  : defaults.retryCount;
 	this.retryDelay   = typeof options.retryDelay   === 'number' ? options.retryDelay  : defaults.retryDelay;
 	this.retryJitter  = typeof options.retryJitter  === 'number' ? options.retryJitter : defaults.retryJitter;
-    this.lockScript   = typeof options.lockScript   === 'function' ? options.lockScript(lockScript) : lockScript;
-    this.unlockScript = typeof options.unlockScript === 'function' ? options.unlockScript(unlockScript) : unlockScript;
-    this.extendScript = typeof options.extendScript === 'function' ? options.extendScript(extendScript) : extendScript;
-    this.multiValueLockScript   = typeof options.multiValueLockScript   === 'function' ? options.multiValueLockScript(multiValueLockScript)     : multiValueLockScript;
-    this.multiValueUnlockScript = typeof options.multiValueUnlockScript === 'function' ? options.multiValueUnlockScript(multiValueUnlockScript) : multiValueUnlockScript;
-    this.multiValueExtendScript = typeof options.multiValueExtendScript === 'function' ? options.multiValueExtendScript(multiValueExtendScript) : multiValueExtendScript;
-    // set the redis servers from additional arguments
-    this.servers = clients;
-    if(this.servers.length === 0)
-        throw new Error('Redlock must be instantiated with at least one redis server.');
+	this.lockScript   = typeof options.lockScript   === 'function' ? options.lockScript(lockScript) : lockScript;
+	this.unlockScript = typeof options.unlockScript === 'function' ? options.unlockScript(unlockScript) : unlockScript;
+	this.extendScript = typeof options.extendScript === 'function' ? options.extendScript(extendScript) : extendScript;
+	this.multiValueLockScript   = typeof options.multiValueLockScript   === 'function' ? options.multiValueLockScript(multiValueLockScript)     : multiValueLockScript;
+	this.multiValueUnlockScript = typeof options.multiValueUnlockScript === 'function' ? options.multiValueUnlockScript(multiValueUnlockScript) : multiValueUnlockScript;
+	this.multiValueExtendScript = typeof options.multiValueExtendScript === 'function' ? options.multiValueExtendScript(multiValueExtendScript) : multiValueExtendScript;
+	// set the redis servers from additional arguments
+	this.servers = clients;
+	if(this.servers.length === 0)
+		throw new Error('Redlock must be instantiated with at least one redis server.');
 }
 
 // Inherit all the EventEmitter methods, like `on`, and `off`
@@ -131,13 +131,13 @@ Redlock.LockError = LockError;
 
 Redlock.prototype.quit = function quit(callback) {
 
-    // quit all clients
-    return Promise.map(this.servers, function(client) {
-        return client.quit();
-    })
+	// quit all clients
+	return Promise.map(this.servers, function(client) {
+		return client.quit();
+	})
 
-        // optionally run callback
-        .nodeify(callback);
+	// optionally run callback
+	.nodeify(callback);
 };
 
 
@@ -155,9 +155,9 @@ Redlock.prototype.quit = function quit(callback) {
 // )
 // ```
 Redlock.prototype.acquire =
-    Redlock.prototype.lock = function lock(resource, ttl, callback) {
-        return this._lock(resource, null, ttl, callback);
-    };
+	Redlock.prototype.lock = function lock(resource, ttl, callback) {
+		return this._lock(resource, null, ttl, callback);
+	};
 
 // lock
 // ----
@@ -190,81 +190,81 @@ Redlock.prototype.disposer = function disposer(resource, ttl, errorHandler) {
 // attempt to restore the lock on nodes that failed to release. It is safe to re-attempt an
 // unlock or to ignore the error, as the lock will automatically expire after its timeout.
 Redlock.prototype.release =
-    Redlock.prototype.unlock = function unlock(lock, callback) {
-        var self = this;
+	Redlock.prototype.unlock = function unlock(lock, callback) {
+		var self = this;
 
-        // immediately invalidate the lock
-        lock.expiration = 0;
+		// immediately invalidate the lock
+		lock.expiration = 0;
 
-        return new Promise(function(resolve, reject) {
+		return new Promise(function(resolve, reject) {
 
-            // the number of servers which have agreed to release this lock
-            var votes = 0;
+			// the number of servers which have agreed to release this lock
+			var votes = 0;
 
-            // the number of votes needed for consensus
-            var quorum = Math.floor(self.servers.length / 2) + 1;
+			// the number of votes needed for consensus
+			var quorum = Math.floor(self.servers.length / 2) + 1;
 
-            // the number of async redis calls still waiting to finish
-            var waiting = self.servers.length;
+			// the number of async redis calls still waiting to finish
+			var waiting = self.servers.length;
 
-            // release the lock on each server
-            self.servers.forEach(function(server){
-                return self.isMultiResource(lock.resource) ? server.eval([multiValueUnlockScript, lock.resource.length].concat(lock.resource).concat([lock.value]), loop) : server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
-            });
+			// release the lock on each server
+			self.servers.forEach(function(server){
+				return self.isMultiResource(lock.resource) ? server.eval([multiValueUnlockScript, lock.resource.length].concat(lock.resource).concat([lock.value]), loop) : server.eval(self.unlockScript, 1, lock.resource, lock.value, loop);
+			});
 
-            function loop(err, response) {
-                if(err) self.emit('clientError', err);
+			function loop(err, response) {
+				if(err) self.emit('clientError', err);
 
-                // - if the lock was released by this call, it will return 1
-                // - if the lock has already been released, it will return 0
-                //    - it may have been re-acquired by another process
-                //    - it may hava already been manually released
-                //    - it may have expired
+				// - if the lock was released by this call, it will return 1
+				// - if the lock has already been released, it will return 0
+				//    - it may have been re-acquired by another process
+				//    - it may hava already been manually released
+				//    - it may have expired
 
-                if(typeof response === 'string')
-                    response = parseInt(response);
+				if(typeof response === 'string')
+					response = parseInt(response);
 
-                if(response === 0 || response === 1)
-                    votes++;
+				if(response === 0 || response === 1)
+					votes++;
 
-                if(waiting-- > 1) return;
+				if(waiting-- > 1) return;
 
-                // SUCCESS: there is concensus and the lock is released
-                if(votes >= quorum)
-                    return resolve();
+				// SUCCESS: there is concensus and the lock is released
+				if(votes >= quorum)
+					return resolve();
 
-                // FAILURE: the lock could not be released
-                return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
-            }
-        })
+				// FAILURE: the lock could not be released
+				return reject(new LockError('Unable to fully release the lock on resource "' + lock.resource + '".'));
+			}
+		})
 
-            // optionally run callback
-            .nodeify(callback);
-    };
+			// optionally run callback
+			.nodeify(callback);
+	};
 
 
 // extend
 // ------
 // This method extends a valid lock by the provided `ttl`.
 Redlock.prototype.extend = function extend(lock, ttl, callback) {
-    var self = this;
+	var self = this;
 
-    // the lock has expired
-    if(lock.expiration < Date.now())
-        return Promise.reject(new LockError('Cannot extend lock on resource "' + lock.resource + '" because the lock has already expired.', 0)).nodeify(callback);
+	// the lock has expired
+	if(lock.expiration < Date.now())
+		return Promise.reject(new LockError('Cannot extend lock on resource "' + lock.resource + '" because the lock has already expired.', 0)).nodeify(callback);
 
-    // extend the lock
-    return self._lock(lock.resource, lock.value, ttl)
+	// extend the lock
+	return self._lock(lock.resource, lock.value, ttl)
 
-        // modify and return the original lock object
-        .then(function(extension){
-            lock.value      = extension.value;
-            lock.expiration = extension.expiration;
-            return lock;
-        })
+		// modify and return the original lock object
+		.then(function(extension){
+			lock.value      = extension.value;
+			lock.expiration = extension.expiration;
+			return lock;
+		})
 
-        // optionally run callback
-        .nodeify(callback);
+		// optionally run callback
+		.nodeify(callback);
 };
 
 
@@ -298,91 +298,91 @@ Redlock.prototype.extend = function extend(lock, ttl, callback) {
 // )
 // ```
 Redlock.prototype._lock = function _lock(resource, value, ttl, callback) {
-    var self = this;
-    return new Promise(function(resolve, reject) {
-        var request;
+	var self = this;
+	return new Promise(function(resolve, reject) {
+		var request;
 
-        // the number of times we have attempted this lock
-        var attempts = 0;
-
-
-        // create a new lock
-        if(value === null) {
-            value = self._random();
-            request = function(server, loop){
-                // alternative using spread operator [multiValueLockScript, resource.length, ...resource, value, ttl] but not supported in old js versions
-                return self.isMultiResource(resource) ? server.eval([multiValueLockScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.lockScript, 1, resource, value, ttl, loop);
-            };
-        }
-
-        // extend an existing lock
-        else {
-            request = function(server, loop){
-                return self.isMultiResource(resource) ? server.eval([multiValueExtendScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.extendScript, 1, resource, value, ttl, loop);
-            };
-        }
-
-        function attempt(){
-            attempts++;
-
-            // the time when this attempt started
-            var start = Date.now();
-
-            // the number of servers which have agreed to this lock
-            var votes = 0;
-
-            // the number of votes needed for consensus
-            var quorum = Math.floor(self.servers.length / 2) + 1;
-
-            // the number of async redis calls still waiting to finish
-            var waiting = self.servers.length;
-
-            function loop(err, response) {
-                if(err) self.emit('clientError', err);
-                if(response) votes++;
-                if(waiting-- > 1) return;
-
-                // Add 2 milliseconds to the drift to account for Redis expires precision, which is 1 ms,
-                // plus the configured allowable drift factor
-                var drift = Math.round(self.driftFactor * ttl) + 2;
-                var lock = new Lock(self, resource, value, start + ttl - drift, attempts);
-
-                // SUCCESS: there is concensus and the lock is not expired
-                if(votes >= quorum && lock.expiration > Date.now())
-                    return resolve(lock);
+		// the number of times we have attempted this lock
+		var attempts = 0;
 
 
-                // remove this lock from servers that voted for it
-                return lock.unlock(function(){
+		// create a new lock
+		if(value === null) {
+			value = self._random();
+			request = function(server, loop){
+				// alternative using spread operator [multiValueLockScript, resource.length, ...resource, value, ttl] but not supported in old js versions
+				return self.isMultiResource(resource) ? server.eval([multiValueLockScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.lockScript, 1, resource, value, ttl, loop);
+			};
+		}
 
-                    // RETRY
-                    if(self.retryCount === -1 || attempts <= self.retryCount)
-                        return setTimeout(attempt, Math.max(0, self.retryDelay + Math.floor((Math.random() * 2 - 1) * self.retryJitter)));
+		// extend an existing lock
+		else {
+			request = function(server, loop){
+				return self.isMultiResource(resource) ? server.eval([multiValueExtendScript, resource.length].concat(resource).concat([value, ttl]), loop) : server.eval(self.extendScript, 1, resource, value, ttl, loop);
+			};
+		}
 
-                    // FAILED
-                    return reject(new LockError('Exceeded ' + self.retryCount + ' attempts to lock the resource "' + resource + '".', attempts));
-                });
-            }
+		function attempt(){
+			attempts++;
 
-            return self.servers.forEach(function(server){
-                return request(server, loop);
-            });
-        }
+			// the time when this attempt started
+			var start = Date.now();
 
-        return attempt();
-    })
+			// the number of servers which have agreed to this lock
+			var votes = 0;
 
-        // optionally run callback
-        .nodeify(callback);
+			// the number of votes needed for consensus
+			var quorum = Math.floor(self.servers.length / 2) + 1;
+
+			// the number of async redis calls still waiting to finish
+			var waiting = self.servers.length;
+
+			function loop(err, response) {
+				if(err) self.emit('clientError', err);
+				if(response) votes++;
+				if(waiting-- > 1) return;
+
+				// Add 2 milliseconds to the drift to account for Redis expires precision, which is 1 ms,
+				// plus the configured allowable drift factor
+				var drift = Math.round(self.driftFactor * ttl) + 2;
+				var lock = new Lock(self, resource, value, start + ttl - drift, attempts);
+
+				// SUCCESS: there is concensus and the lock is not expired
+				if(votes >= quorum && lock.expiration > Date.now())
+					return resolve(lock);
+
+
+				// remove this lock from servers that voted for it
+				return lock.unlock(function(){
+
+					// RETRY
+					if(self.retryCount === -1 || attempts <= self.retryCount)
+						return setTimeout(attempt, Math.max(0, self.retryDelay + Math.floor((Math.random() * 2 - 1) * self.retryJitter)));
+
+					// FAILED
+					return reject(new LockError('Exceeded ' + self.retryCount + ' attempts to lock the resource "' + resource + '".', attempts));
+				});
+			}
+
+			return self.servers.forEach(function(server){
+				return request(server, loop);
+			});
+		}
+
+		return attempt();
+	})
+
+		// optionally run callback
+		.nodeify(callback);
 };
 
 
 Redlock.prototype._random = function _random(){
-    return crypto.randomBytes(16).toString('hex');
+	return crypto.randomBytes(16).toString('hex');
 };
 
 Redlock.prototype.isMultiResource = function isMultiResource(resource) {
-    return Array.isArray(resource);
+	return Array.isArray(resource);
 };
 
 module.exports = Redlock;

--- a/test.js
+++ b/test.js
@@ -17,7 +17,8 @@ function test(name, clients){
 		retryJitter: 50
 	});
 
-	var resource = 'Redlock:test:resource';
+    var resource = 'Redlock:test:resource';
+    var multiValueResource = ['Redlock:test:mvResource1','Redlock:test:mvResource2'];
 	var error    = 'Redlock:test:error';
 
 	describe('Redlock: ' + name, function(){
@@ -59,13 +60,19 @@ function test(name, clients){
 			var opts = {
 				lockScript: function(lockScript) { return lockScript + 'and 1'; },
 				unlockScript: function(unlockScript) { return unlockScript + 'and 2'; },
-				extendScript: function(extendScript) { return extendScript + 'and 3'; }
+                extendScript: function(extendScript) { return extendScript + 'and 3'; },
+                multiValueLockScript: function(multiValueLockScript) { return multiValueLockScript + 'and 4'; },
+                multiValueUnlockScript: function(multiValueUnlockScript) { return multiValueUnlockScript + 'and 5'; },
+                multiValueExtendScript: function(multiValueExtendScript) { return multiValueExtendScript + 'and 6'; }
 			};
 			var customRedlock = new Redlock(clients, opts);
 			var i = 1;
 			assert.equal(customRedlock.lockScript, redlock.lockScript + 'and ' + i++);
 			assert.equal(customRedlock.unlockScript, redlock.unlockScript + 'and ' + i++);
-			assert.equal(customRedlock.extendScript, redlock.extendScript + 'and ' + i);
+            assert.equal(customRedlock.extendScript, redlock.extendScript + 'and ' + i++);
+            assert.equal(customRedlock.multiValueLockScript, redlock.multiValueLockScript + 'and ' + i++);
+            assert.equal(customRedlock.multiValueUnlockScript, redlock.multiValueUnlockScript + 'and ' + i++);
+            assert.equal(customRedlock.multiValueExtendScript, redlock.multiValueExtendScript + 'and ' + i);
 		});
 
 		describe('callbacks', function(){
@@ -93,11 +100,11 @@ function test(name, clients){
 			var two;
 			var two_expiration;
 			it('should wait until a lock expires before issuing another lock', function(done) {
-				assert(one, 'Could not run because a required previous test failed.');
+                assert(one, 'Could not run because a required previous test failed.');
 				redlock.lock(resource, 800, function(err, lock){
-					if(err) throw err;
+                    if(err) throw err;
 					assert.isObject(lock);
-					assert.isAbove(lock.expiration, Date.now()-1);
+                    assert.isAbove(lock.expiration, Date.now()-1);
 					assert.isAbove(Date.now()+1, one.expiration);
 					assert.isAbove(lock.attempts, 1);
 					two = lock;
@@ -442,7 +449,394 @@ function test(name, clients){
 					clients[i].del(resource, cb);
 				}
 			});
-		});
+        });
+        
+        describe('callbacksMultiValue', function(){
+			before(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+                    for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+
+			var one;
+			it('should lock a multivalue resource', function(done) {
+				redlock.lock(multiValueResource, 200, function(err, lock){
+					if(err) throw err;
+					assert.isObject(lock);
+					assert.instanceOf(lock, Redlock.Lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.equal(lock.attempts, 1);
+					one = lock;
+					done();
+				});
+			});
+
+			var two;
+			var two_expiration;
+			it('should wait until a lock expires before issuing another lock', function(done) {
+                assert(one, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 800, function(err, lock){
+                    if(err) throw err;
+                    assert.isObject(lock);
+                    assert.isAbove(lock.expiration, Date.now()-1);
+                    assert.isAbove(Date.now()+1, one.expiration);
+                    assert.isAbove(lock.attempts, 1);
+					two = lock;
+					two_expiration = lock.expiration;
+					done();
+				});
+			});
+
+			it('should unlock a multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.unlock(done);
+				assert.equal(two.expiration, 0, 'Failed to immediately invalidate the lock.');
+			});
+
+			it('should unlock an already-unlocked multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.unlock(done);
+			});
+
+			it('should error when unable to fully release a multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				var failingTwo = Object.create(two);
+				failingTwo.resource = error;
+				failingTwo.unlock(function(err) {
+					assert.isNotNull(err);
+					done();
+				});
+			});
+
+			it('should fail to extend a lock on an already-unlocked multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.extend(200, function(err, lock){
+					assert.isNotNull(err);
+					assert.instanceOf(err, Redlock.LockError);
+					assert.equal(err.attempts, 0);
+					done();
+				});
+			});
+
+			var three;
+			it('should issue another lock immediately after a multivalue resource is unlocked', function(done) {
+				assert(two_expiration, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 800, function(err, lock){
+					if(err) throw err;
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.isBelow(Date.now()-1, two_expiration);
+					assert.equal(lock.attempts, 1);
+					three = lock;
+					done();
+				});
+			});
+
+			var four;
+			it('should extend an unexpired multivalue lock', function(done) {
+				assert(three, 'Could not run because a required previous test failed.');
+				three.extend(800, function(err, lock){
+					if(err) throw err;
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.isAbove(lock.expiration, three.expiration-1);
+					assert.equal(lock.attempts, 1);
+					assert.equal(three, lock);
+					four = lock;
+					done();
+				});
+			});
+
+			it('should fail after the maximum retry count is exceeded', function(done) {
+				assert(four, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 200, function(err, lock){
+					assert.isNotNull(err);
+					assert.instanceOf(err, Redlock.LockError);
+					assert.equal(err.attempts, 3);
+					done();
+				});
+			});
+
+			it('should fail to extend an expired lock', function(done) {
+				assert(four, 'Could not run because a required previous test failed.');
+				setTimeout(function(){
+					three.extend(800, function(err, lock){
+						assert.isNotNull(err);
+						assert.instanceOf(err, Redlock.LockError);
+						assert.equal(err.attempts, 0);
+						done();
+					});
+				}, four.expiration - Date.now() + 100);
+			});
+
+			it('should issue another lock immediately after a resource is expired', function(done) {
+				assert(four, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 800, function(err, lock){
+					if(err) throw err;
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.equal(lock.attempts, 1);
+					done();
+				});
+			});
+
+			after(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+                    for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+        });
+        
+        describe('promisesMultiValue', function(){
+			before(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+					for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+
+			var one;
+			it('should lock a multivalue resource', function(done) {
+				redlock.lock(multiValueResource, 200)
+				.done(function(lock){
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.equal(lock.attempts, 1);
+					one = lock;
+					done();
+				}, done);
+			});
+
+			var two;
+			var two_expiration;
+			it('should wait until a multivalue lock expires before issuing another lock', function(done) {
+				assert(one, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 800)
+				.done(function(lock){
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.isAbove(Date.now()+1, one.expiration);
+					assert.isAbove(lock.attempts, 1);
+					two = lock;
+					two_expiration = lock.expiration;
+					done();
+				}, done);
+			});
+
+			it('should unlock a multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.unlock().done(done, done);
+			});
+
+			it('should unlock an already-unlocked multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.unlock().done(done, done);
+			});
+
+			it('should error when unable to fully release a multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				var failingTwo = Object.create(two);
+				failingTwo.resource = error;
+				failingTwo.unlock().done(done, function(err) {
+					assert.isNotNull(err);
+					done();
+				});
+			});
+
+			it('should fail to extend a lock on an already-unlocked multivalue resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				two.extend(200)
+				.done(function(){
+					done(new Error('Should have failed with a LockError'));
+				}, function(err){
+					assert.instanceOf(err, Redlock.LockError);
+					assert.equal(err.attempts, 0);
+					done();
+				});
+			});
+
+			var three;
+			it('should issue another lock immediately after a multivalue resource is unlocked', function(done) {
+				assert(two_expiration, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 800)
+				.done(function(lock){
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.isBelow(Date.now()-1, two_expiration);
+					assert.equal(lock.attempts, 1);
+					three = lock;
+					done();
+				}, done);
+			});
+
+			var four;
+			it('should extend an unexpired lock', function(done) {
+				assert(three, 'Could not run because a required previous test failed.');
+				three.extend(800)
+				.done(function(lock){
+					assert.isObject(lock);
+					assert.isAbove(lock.expiration, Date.now()-1);
+					assert.isAbove(lock.expiration, three.expiration-1);
+					assert.equal(lock.attempts, 1);
+					assert.equal(three, lock);
+					four = lock;
+					done();
+				}, done);
+			});
+
+			it('should fail after the maximum retry count is exceeded', function(done) {
+				assert(four, 'Could not run because a required previous test failed.');
+				redlock.lock(multiValueResource, 200)
+				.done(function(){
+					done(new Error('Should have failed with a LockError'));
+				}, function(err){
+					assert.instanceOf(err, Redlock.LockError);
+					assert.equal(err.attempts, 3);
+					done();
+				});
+			});
+
+			it('should fail to extend an expired lock', function(done) {
+				assert(four, 'Could not run because a required previous test failed.');
+				setTimeout(function(){
+					three.extend(800)
+					.done(function(){
+						done(new Error('Should have failed with a LockError'));
+					}, function(err){
+						assert.instanceOf(err, Redlock.LockError);
+						assert.equal(err.attempts, 0);
+						done();
+					});
+				}, four.expiration - Date.now() + 100);
+			});
+
+			after(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+					for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+        });
+        
+        describe('disposerMultiValue', function(){
+			before(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+					for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+
+			var one;
+			var one_expiration;
+			it('should automatically release a lock after the using block', function(done) {
+				Promise.using(
+					redlock.disposer(multiValueResource, 200),
+					function(lock){
+						assert.isObject(lock);
+						assert.isAbove(lock.expiration, Date.now()-1);
+						assert.equal(lock.attempts, 1);
+						one = lock;
+						one_expiration = lock.expiration;
+					}
+				).done(done, done);
+			});
+
+			var two;
+			var two_expiration;
+			it('should issue another lock immediately after a resource is unlocked', function(done) {
+				assert(one_expiration, 'Could not run because a required previous test failed.');
+				Promise.using(
+					redlock.disposer(multiValueResource, 800),
+					function(lock){
+						assert.isObject(lock);
+						assert.isAbove(lock.expiration, Date.now()-1);
+						assert.isBelow(Date.now()-1, one_expiration);
+						assert.equal(lock.attempts, 1);
+						two = lock;
+						two_expiration = lock.expiration;
+					}
+				).done(done, done);
+			});
+
+			it('should call unlockErrorHandler when unable to fully release a resource', function(done) {
+				assert(two, 'Could not run because a required previous test failed.');
+				var errs = 0;
+				var lock;
+				Promise.using(
+					redlock.disposer(multiValueResource, 800, function(err) {
+						errs++;
+					}),
+					function(l){
+						lock = l;
+						lock.resource = error;
+					}
+				).done(function() {
+					assert.equal(errs, 1);
+					lock.resource = multiValueResource;
+					lock.unlock().done(done, done);
+				}, done);
+			});
+
+			var three_original, three_extended;
+			var three_original_expiration;
+			var three_extended_expiration;
+			it('should automatically release an extended lock', function(done) {
+                assert(two_expiration, 'Could not run because a required previous test failed.');
+				Promise.using(
+					redlock.disposer(multiValueResource, 200),
+					function(lock){
+						assert.isObject(lock);
+						assert.isAbove(lock.expiration, Date.now()-1);
+						assert.isBelow(Date.now()-1, two_expiration);
+						three_original = lock;
+						three_original_expiration = lock.expiration;
+						return Promise.delay(100)
+						.then(function(){ return lock.extend(200); })
+						.then(function(extended) {
+							assert.isObject(extended);
+							assert.isAbove(extended.expiration, Date.now()-1);
+							assert.isBelow(Date.now()-1, three_original_expiration);
+                            assert.isAbove(extended.expiration, three_original_expiration);
+							assert.equal(lock.attempts, 1);
+							assert.equal(extended, lock);
+							three_extended = extended;
+							three_extended_expiration = extended.expiration;
+						});
+					}
+				)
+				.then(function(){
+					assert.equal(three_original.expiration, 0);
+					assert.equal(three_extended.expiration, 0);
+				}).done(done, done);
+			});
+
+			after(function(done) {
+				var err;
+				var l = clients.length; function cb(e){ if(e) err = e; l--; if(l === 0) done(err); }
+				for (var i = clients.length - 1; i >= 0; i--) {
+					for (var j = multiValueResource.length - 1; j >= 0; j--) {
+                        clients[i].del(multiValueResource[j], cb);
+                    }
+				}
+			});
+        });
 
 		describe('quit', function() {
 			it('should quit all clients', function(done){


### PR DESCRIPTION
Add support for locking multiple resources

Locking of multiple resources in single call is "hard" due to nature of redis. Even when using MULTI (transaction support) all commands which are queued successfully will be executed (so we can't rely on redis to fail on already set key).

This branch provides a sort-of-workaround by checking existence of values but it still doesn't provide strong guarantees for settings/removing/extending all resources.