### PR TITLE
Replace `table.getn` with length operator

### DIFF
--- a/redlock.js
+++ b/redlock.js
@@ -20,7 +20,7 @@ const lockScript = `
 	end
 
 	-- Return the number of entries added.
-	return table.getn(KEYS)
+	return #KEYS
 `;
 
 const unlockScript = `
@@ -51,7 +51,7 @@ const extendScript = `
 	end
 
 	-- Return the number of entries updated.
-	return table.getn(KEYS)
+	return #KEYS
 `;
 
 // defaults


### PR DESCRIPTION
`table.getn` was removed in Lua 5.2, in favor of the `#` operator - see e.g. https://stackoverflow.com/questions/11890125/lua-table-library-removed.

While Redis itself still seems to support the old syntax, this change allows compatibility with mock libraries which may rely on newer Lua versions. In my case I ran into issues with https://github.com/stipsan/ioredis-mock.

In the meantime, if anyone is looking a solution to use `redlock` with `ioredis-mock` or similar, this has worked for me:

```javascript
const replaceGetn = (lua: string) => {
  // table.getn(KEYS) --> #KEYS
  return lua.replace(/table\.getn\(([A-Za-z0-9]+)\)/g, '#$1');
}
const redlock = new Redlock(clients, {
  lockScript: replaceGetn,
  extendScript: replaceGetn,
});
```