### PR TITLE
feat: drop bluebird for native promises

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
 	"node": true,
+	"esversion": 7,
 	"unused": "vars",
 	"multistr": true,
 	"globals": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "mocha": "^8.1.3",
     "redis": "^3.0.2"
   },
-  "dependencies": {
-    "p-map": "^4.0.0"
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=8.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "redis": "^3.0.2"
   },
   "dependencies": {
-    "bluebird": "^3.7.2"
+    "p-map": "^4.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/redlock.js
+++ b/redlock.js
@@ -2,7 +2,6 @@
 
 const util = require('util');
 const crypto = require('crypto');
-const pMap = require('p-map');
 const EventEmitter = require('events');
 
 // constants
@@ -161,9 +160,9 @@ Redlock.LockError = LockError;
 Redlock.prototype.quit = function quit(callback) {
 
 	// quit all clients
-	return pMap(this.servers, function(client) {
+	return Promise.all(this.servers.map(function(client) {
 		return client.quit();
-	})
+	}))
 
 	// optionally run callback
 	.nodeify(callback);


### PR DESCRIPTION
Bluebird isn't really doing anything for us, except messing up async hooks and stack traces in my app.

BREAKING CHANGE: all methods' return types changed, and `disposer`-based interface is just gone.

---

We could avoid that `p-map` dependency by just using Promise.all, which is pretty much all it's doing anyway.

`nodeify` needs to not be a monkeypatch, but the diff is easier to read here. I'll fix it properly. Personally I'd just totally drop callbacks, but doing so causes the tests to go nuts in some way I'm totally failing to debug.

---

Thoughts?