### PR TITLE
Publish as CommonJS module

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,5 @@
   "dependencies": {
     "node-abort-controller": "^2.0.0"
   },
-  "type": "module",
   "exports": "./dist/index.js"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2020"],
     "target": "es2018",
-    "module": "es2020",
+    "module": "commonjs",
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "./dist",


### PR DESCRIPTION
I experienced both these issues, which occur because of the distribution as an
ES module:

https://github.com/mike-marcacci/node-redlock/issues/98 https://github.com/mike-marcacci/node-redlock/issues/96

I'm working on a node project with several dependencies on typescript projects
(including ioredis), none of which publishes as ES module. Migrating the project
to ES modules (in compiler options) comes with quite a few inconveniences and
leads to a degradation of the developer experience with VS code. In my opinion
it isn't a reasonable option for us at the moment, so I'd love to see this
changed.
