### PR TITLE
Compatibility with typescript 4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ioredis": "^4.19.2",
     "nodemon": "^2.0.6",
     "prettier": "^2.2.1",
-    "typescript": "^4.1.2"
+    "typescript": "~4.4.3"
   },
   "scripts": {
     "format": "prettier --list-different --write '**/*.{json,yml,md,ts}'",

--- a/src/index.ts
+++ b/src/index.ts
@@ -708,7 +708,7 @@ export default class Redlock extends EventEmitter {
           return (extension = extend());
         }
 
-        signal.error = error;
+        signal.error = error instanceof Error ? error : new Error(`${error}`);
         controller.abort();
       }
     }


### PR DESCRIPTION
Type of catch variable is now `unknown`. Since typescript does not
follow semver, and might introduce more breaking changes with minor
versions, this also fixes the minor version in package.json.