### PR TITLE
Fix types of `using` function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -260,7 +260,7 @@ test("the `using` helper acquires, extends, and releases locks", async (t) => {
 
   const duration = 300;
 
-  await redlock.using(
+  const valueP: Promise<string | null> = redlock.using(
     ["x"],
     duration,
     {
@@ -288,6 +288,8 @@ test("the `using` helper acquires, extends, and releases locks", async (t) => {
       return lockValue;
     }
   );
+
+  await valueP;
 
   t.is(await redis.get("x"), null, "The lock was not released.");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,13 +643,13 @@ export default class Redlock extends EventEmitter {
     resources: string[],
     duration: number,
     settings: Partial<Settings>,
-    routine?: (signal: RedlockAbortSignal) => T
+    routine?: (signal: RedlockAbortSignal) => Promise<T>
   ): Promise<T>;
 
   public async using<T>(
     resources: string[],
     duration: number,
-    routine: (signal: RedlockAbortSignal) => T
+    routine: (signal: RedlockAbortSignal) => Promise<T>
   ): Promise<T>;
 
   public async using<T>(
@@ -658,8 +658,8 @@ export default class Redlock extends EventEmitter {
     settingsOrRoutine:
       | undefined
       | Partial<Settings>
-      | ((signal: RedlockAbortSignal) => T),
-    optionalRoutine?: (signal: RedlockAbortSignal) => T
+      | ((signal: RedlockAbortSignal) => Promise<T>),
+    optionalRoutine?: (signal: RedlockAbortSignal) => Promise<T>
   ): Promise<T> {
     const settings =
       settingsOrRoutine && typeof settingsOrRoutine !== "function"


### PR DESCRIPTION
Before this change using was returning `Promise<Promise<T>>` which can
interfere with the types one has. This fixes that my being explicit that
the `routine` must be an async function.

This also modifies the tests to add a type check that we're getting back
the type we expect.

Please let me know what else would be helpful from this PR!