### PR TITLE
Fix settings type for acquire

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,7 @@ export default class Redlock extends EventEmitter {
   public async acquire(
     resources: string[],
     duration: number,
-    settings?: Settings
+    settings?: Partial<Settings>
   ): Promise<Lock> {
     const start = Date.now();
     const value = this._random();


### PR DESCRIPTION
The type definitions for `acquire` seem to be incorrect in requiring a full `Settings` object if specified, when all others accept `Partial<Settings>`