### PR TITLE
Fix extension failure issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,6 @@ export default class Redlock extends EventEmitter {
       throw new Error("Duration must be an integer value in milliseconds.");
     }
 
-    const start = Date.now();
     const value = this._random();
 
     try {
@@ -312,6 +311,8 @@ export default class Redlock extends EventEmitter {
         [value, duration],
         settings
       );
+
+      const start = Date.now();
 
       // Add 2 milliseconds to the drift to account for Redis expires precision,
       // which is 1 ms, plus the configured allowable drift factor.


### PR DESCRIPTION
Issue https://github.com/mike-marcacci/node-redlock/issues/166

The lock's timer should start counting *after* the acquisition reaches quorum, not before. Otherwise, the lock is unfairly penalized for long acquisition wait time, and its extensions subsequent fail.

