### PR TITLE
Fix release on expired locks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -313,12 +313,7 @@ export default class Redlock extends EventEmitter {
         settings
       );
 
-      // Add 2 milliseconds to the drift to account for Redis expires precision,
-      // which is 1 ms, plus the configured allowable drift factor.
-      const drift =
-        Math.round(
-          (settings?.driftFactor ?? this.settings.driftFactor) * duration
-        ) + 2;
+      const drift = this.calculateDrift(duration, settings);
 
       return new Lock(
         this,
@@ -351,6 +346,12 @@ export default class Redlock extends EventEmitter {
     lock: Lock,
     settings?: Partial<Settings>
   ): Promise<ExecutionResult> {
+    // Check if lock already expired and quit early
+    if (lock.expiration < Date.now()) {
+      const attempts: Promise<ExecutionStats>[] = [];
+      return Promise.resolve({ attempts });
+    }
+
     // Immediately invalidate the lock.
     lock.expiration = 0;
 
@@ -360,6 +361,22 @@ export default class Redlock extends EventEmitter {
       lock.resources,
       [lock.value],
       settings
+    );
+  }
+
+  /**
+   * This method calculates drift for the provided `duration`.
+   */
+  public calculateDrift(
+    duration: number,
+    settings?: Partial<Settings>
+  ): number {
+    // Add 2 milliseconds to the drift to account for Redis expires precision,
+    // which is 1 ms, plus the configured allowable drift factor.
+    return (
+      Math.round(
+        (settings?.driftFactor ?? this.settings.driftFactor) * duration
+      ) + 2
     );
   }
 
@@ -392,12 +409,7 @@ export default class Redlock extends EventEmitter {
     // Invalidate the existing lock.
     existing.expiration = 0;
 
-    // Add 2 milliseconds to the drift to account for Redis expires precision,
-    // which is 1 ms, plus the configured allowable drift factor.
-    const drift =
-      Math.round(
-        (settings?.driftFactor ?? this.settings.driftFactor) * duration
-      ) + 2;
+    const drift = this.calculateDrift(duration, settings);
 
     const replacement = new Lock(
       this,


### PR DESCRIPTION
This PR:
- hopefully fixes fixes https://github.com/mike-marcacci/node-redlock/issues/168 
- refactors drift calculation to reduce repetition and allow usage in e.g. tests


Note:
- Some tests seem to be non-predictable, e.g.  ` multi › cluster - acquires, extends, and releases a single lock` fails with `The lock value was incorrect.`, but it seems to happen [outside of this PR as well](https://github.com/mike-marcacci/node-redlock/runs/6967569712?check_suite_focus=true)
- Better way would be to actually try to expire expired locks (👀), just to be sure(basically ignore `count`  from `RELEASE_SCRIPT`). But I couldn't find an elegant way to do that