### PR TITLE
Fix extension failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,11 @@ export default class Redlock extends EventEmitter {
     const attempts: Promise<ExecutionStats>[] = [];
 
     while (true) {
-      const { vote, stats, start } = await this._attemptOperation(script, keys, args);
+      const { vote, stats, start } = await this._attemptOperation(
+        script,
+        keys,
+        args
+      );
 
       attempts.push(stats);
 
@@ -472,10 +476,9 @@ export default class Redlock extends EventEmitter {
     keys: string[],
     args: (string | number)[]
   ): Promise<
-    | { vote: "for"; stats: Promise<ExecutionStats>; start: number;}
-    | { vote: "against"; stats: Promise<ExecutionStats>; start: number; }
+    | { vote: "for"; stats: Promise<ExecutionStats>; start: number }
+    | { vote: "against"; stats: Promise<ExecutionStats>; start: number }
   > {
-    
     const start = Date.now();
 
     return await new Promise((resolve) => {
@@ -514,7 +517,7 @@ export default class Redlock extends EventEmitter {
           resolve({
             vote: "for",
             stats: statsPromise,
-            start
+            start,
           });
         }
 
@@ -523,7 +526,7 @@ export default class Redlock extends EventEmitter {
           resolve({
             vote: "against",
             stats: statsPromise,
-            start
+            start,
           });
         }
 


### PR DESCRIPTION
#169 

Expiration time of the lock is calculated by adding duration of lock on start time but start time in the code is the time when acquiring of lock is attempted for the first time. Expiration time becomes too early, hence causing the failure in extension of locks.

@mike-marcacci I saw PR:  https://github.com/mike-marcacci/node-redlock/pull/167 where you've mentioned that the expiration time should be same or early than the one in redis. This PR will keep lock's expiration time as close to the redis expiration but never later