### PR TITLE
Fix Auto extending locks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export type ExecutionStats = {
  */
 export type ExecutionResult = {
   attempts: ReadonlyArray<Promise<ExecutionStats>>;
+  start: number;
 };
 
 /**
@@ -302,11 +303,10 @@ export default class Redlock extends EventEmitter {
       throw new Error("Duration must be an integer value in milliseconds.");
     }
 
-    const start = Date.now();
     const value = this._random();
 
     try {
-      const { attempts } = await this._execute(
+      const { attempts, start } = await this._execute(
         this.scripts.acquireScript,
         resources,
         [value, duration],
@@ -436,13 +436,17 @@ export default class Redlock extends EventEmitter {
     const attempts: Promise<ExecutionStats>[] = [];
 
     while (true) {
-      const { vote, stats } = await this._attemptOperation(script, keys, args);
+      const { vote, stats, start } = await this._attemptOperation(
+        script,
+        keys,
+        args
+      );
 
       attempts.push(stats);
 
       // The operation achieved a quorum in favor.
       if (vote === "for") {
-        return { attempts };
+        return { attempts, start };
       }
 
       // Wait before reattempting.
@@ -472,9 +476,11 @@ export default class Redlock extends EventEmitter {
     keys: string[],
     args: (string | number)[]
   ): Promise<
-    | { vote: "for"; stats: Promise<ExecutionStats> }
-    | { vote: "against"; stats: Promise<ExecutionStats> }
+    | { vote: "for"; stats: Promise<ExecutionStats>; start: number }
+    | { vote: "against"; stats: Promise<ExecutionStats>; start: number }
   > {
+    const start = Date.now();
+
     return await new Promise((resolve) => {
       const clientResults = [];
       for (const client of this.clients) {
@@ -511,6 +517,7 @@ export default class Redlock extends EventEmitter {
           resolve({
             vote: "for",
             stats: statsPromise,
+            start,
           });
         }
 
@@ -519,6 +526,7 @@ export default class Redlock extends EventEmitter {
           resolve({
             vote: "against",
             stats: statsPromise,
+            start,
           });
         }
 


### PR DESCRIPTION
https://github.com/mike-marcacci/node-redlock/issues/169

Expiration time of the lock is calculated by adding duration of lock on start time but start time in the code is the time when acquiring of lock is attempted for the first time. Expiration time becomes too early, hence causing the failure in extension of locks.

@mike-marcacci I saw PR: https://github.com/mike-marcacci/node-redlock/pull/167 where you've mentioned that the expiration time should be same or early than the one in redis. This PR will keep lock's expiration time as close to the redis expiration but never later