### PR TITLE
Readme - new args for the using() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ The `using` method wraps and executes a routine in the context of an auto-extend
 The first parameter is an array of resources to lock; the second is the requested lock duration in milliseconds, which MUST NOT contain values after the decimal.
 
 ```ts
-await redlock.using([senderId, recipientId], 5000, async (signal) => {
+await redlock.using(["foo", "bar"], 5000, async (signal) => {
   // Do something...
-  await something();
+  await something("foo");
 
   // Make sure any attempted lock extension has not failed.
   if (signal.aborted) {
@@ -77,7 +77,7 @@ await redlock.using([senderId, recipientId], 5000, async (signal) => {
   }
 
   // Do something else...
-  await somethingElse();
+  await somethingElse("bar");
 });
 ```
 


### PR DESCRIPTION
Going trough the Readme, it made me think that `senderId` and `recipientId` were something specific to the redlock paradigm that I needed to know, instead they are just generic identifiers for the names of the locks, since this is a generic example I think it's better to use something generic like "foo" or "bar".

This is also in line with the next part of the readme, the "acquire" example which uses the string "a" which is clearly a generic identifier