### PR TITLE
skip collection of attempts when maxAttempts is Infinity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -440,7 +440,8 @@ export default class Redlock extends EventEmitter {
         args
       );
 
-      attempts.push(stats);
+      // Infinite retry may result in memory leak when routine() is on hold for long time
+      if (maxAttempts !== Infinity) attempts.push(stats);
 
       // The operation achieved a quorum in favor.
       if (vote === "for") {


### PR DESCRIPTION
Potential issue in a scenario of retryCount = -1 

In the scenario that an app instance can acquire to the lock while other instances wait for the lock, the `attempts` array will keep collecting `stats` as long as the `routine()` is still on hold. E.g. the app instance subscribes to external service for a regular polling may want to hold the lock forever until an error occurs or the app instance is down. That would eventually be a memory-leak issue in other app instances who wait for the lock, because each retry failed to obtain the lock => `attempts` array will collect 1 `stats`.

So in this scenario, there should be either a maximum limit for `attempts` to collect the `stats`, or may just skip the collection.